### PR TITLE
requesting to require tizen api level 4.0

### DIFF
--- a/tizen-project-new/.gitignore
+++ b/tizen-project-new/.gitignore
@@ -16,3 +16,4 @@
 *.tmp
 *~
 res/edje/*.edj
+/SA_Report/

--- a/tizen-project-new/tizen-manifest.xml
+++ b/tizen-project-new/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<manifest xmlns="http://tizen.org/ns/packages" api-version="3.0" package="com.bitstobreath.heart2web" version="1.0.1">
+<manifest xmlns="http://tizen.org/ns/packages" api-version="4.0" package="com.bitstobreath.heart2web" version="1.0.1">
     <author email="names.a93@use.startmail.com" href="https://bitstobreath.com">Austin Hogan</author>
     <description>Send heart rate to a custom machine on the local network at specified intervals.</description>
     <profile name="wearable"/>


### PR DESCRIPTION
Hey.. i just stumbled upon this project.. 

Great implementation..

I Added to my tizen studio and runing as is will not work. however if:

- making api level to tizen 4.0
- configuring watch to set wi-fi on allways

WORKS FLAWLESSLY!!! i had this configuration and it continues to report to the webserver, the watch screen is off and everything works as expected.

Tested on galaxy watch active 2 that has tizen version 5.5